### PR TITLE
Drop typing dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setuptools.setup(
 
     packages=setuptools.find_packages(),
 
-    install_requires=['aiohttp>=2.3.10', 'async_timeout', 'typing>=3,<4'],
+    install_requires=['aiohttp>=2.3.10', 'async_timeout'],
     zip_safe=True,
 
     classifiers=[


### PR DESCRIPTION
Since python 3.5 typing is included and the author indicates to use
the included version since it's more updated and feature complete
than their backport.

From: https://pypi.org/project/typing/

"""
NOTE: in Python 3.5 and later, the typing module lives in the stdlib, and
installing this package has NO EFFECT. To get a newer version of the typing
module in Python 3.5 or later, you have to upgrade to a newer Python (bugfix)
version. For example, typing in Python 3.6.0 is missing the definition of ‘Type’
– upgrading to 3.6.2 will fix this.

Also note that most improvements to the typing module in Python 3.7 will not be
included in this package, since Python 3.7 has some built-in support that is not
present in older versions (See PEP 560.)
"""